### PR TITLE
feat: add traceback info to error

### DIFF
--- a/executor/bin.py
+++ b/executor/bin.py
@@ -4,6 +4,7 @@ import sys
 import importlib
 import importlib.util
 import os
+import traceback
 
 from vocana import setup_vocana_sdk
 
@@ -12,8 +13,9 @@ def run():
     try:
         index_module = load_module(get_source())
         index_module.main(sdk.props, sdk)
-    except Exception as e:
-        sdk.send_error(repr(e))
+    except Exception:
+        traceback_str = traceback.format_exc()
+        sdk.send_error(traceback_str)
         sys.exit(1)
 
 def get_source():

--- a/executor/package.json
+++ b/executor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vocana/executor-python",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "files": ["bin.py"],
   "bin": {
     "vocana-executor-python": "bin.py"


### PR DESCRIPTION
https://oomol.atlassian.net/browse/OOM-993


增加 traceback 信息，如果使用 try exception, 打印 e 会丢失调用栈（只有下面的`NameError: name 'someon' is not defined`）。需要使用`traceback`在提取错误的同时，获取到调用栈信息。

```python
$ python example.py
Traceback (most recent call last):
  File "/path/to/example.py", line 4, in <module>
    greet('Chad')
  File "/path/to/example.py", line 2, in greet
    print('Hello, ' + someon)
NameError: name 'someon' is not defined
```