### PR TITLE
fix: plotly get context issue, use cdn, remove html margin

### DIFF
--- a/executor/python_executor/matplot_helper.py
+++ b/executor/python_executor/matplot_helper.py
@@ -14,19 +14,20 @@ def import_helper(logger):
 
     # plotly 的 show() 替换
     try:
+        import sys
         from plotly.io import renderers # type: ignore
         from plotly.io.base_renderers import ExternalRenderer # type: ignore
 
         class OomolRenderer(ExternalRenderer):
             def render(self, fig_dict):
-                var = globals().get('oomol')
+                var = sys.modules["oomol"]
                 if var:
                     context = var.get('context')
 
                     from plotly.io import to_html # type: ignore
                     html = to_html(
                         fig_dict,
-                        include_plotlyjs=True,
+                        include_plotlyjs="cdn", # <-- See comments below.
                         include_mathjax="cdn",
                         full_html=True,
                         default_width="100%",
@@ -34,9 +35,16 @@ def import_helper(logger):
                         validate=False,
                     )
 
+                    # ^ The cdn may be hard to fetch.
+                    # We use CDN here because the html is about 3 MB long,
+                    # but the handler seems only support 100 kB long data.
+                    # If we fixed that later we can use include_plotlyjs=True instead.
+
+                    # The generated html has default body margin 8px in chrome, remove it.
+                    html = html.replace('<body>', '<body style="margin:0">', 1)
                     context.preview({ "type": "html", "data": html })
                 else:
-                    logger.warning("OomolRenderer: no globals().get('oomol')")
+                    logger.warning('plotly: no sys.modules["oomol"]')
 
         renderers['oomol'] = OomolRenderer()
         renderers.default = 'oomol'

--- a/executor/python_executor/matplotlib_oomol/oomol.py
+++ b/executor/python_executor/matplotlib_oomol/oomol.py
@@ -22,4 +22,4 @@ def show(*args, **kwargs):
                 payload = { "type": "image", "data": url }
                 context.preview(payload)
     else:
-        print('matplotlib_oomol: no globals().get("oomol")', file=sys.stderr)
+        print('matplotlib_oomol: no sys.modules["oomol"]', file=sys.stderr)


### PR DESCRIPTION
如果要自己 host plotly.js，可以设置 `include_plotlyjs="url to plotly.js"`, 文档：[plotly.io.to_html](https://plotly.com/python-api-reference/generated/plotly.io.to_html.html#:~:text=If%20a%20string%20that%20ends%20in%20%E2%80%98.js%E2%80%99%2C%20a%20script%20tag%20is%20included%20that%20references%20the%20specified%20path.%20This%20approach%20can%20be%20used%20to%20point%20the%20resulting%20HTML%20file%20to%20an%20alternative%20CDN%20or%20local%20bundle)