### PR TITLE
refactor!: keep lifetime with session

### DIFF
--- a/oocana/oocana/mainframe.py
+++ b/oocana/oocana/mainframe.py
@@ -69,12 +69,11 @@ class Mainframe:
     def report(self, block_info: BlockDict, msg: dict) -> mqtt.MQTTMessageInfo:
         return self.client.publish("report", json.dumps({**block_info, **msg}, ignore_nan=True), qos=1)
     
-    def notify_executor_ready(self, session_id: str, executor_name: str, client_id: str) -> None:
+    def notify_executor_ready(self, session_id: str, executor_name: str) -> None:
         self.client.publish(f"session/{session_id}", json.dumps({
             "type": "ExecutorReady",
             "session_id": session_id,
             "executor_name": executor_name,
-            "client_id": client_id,
         }, ignore_nan=True), qos=1)
 
     def notify_block_ready(self, session_id: str, job_id: str) -> dict:


### PR DESCRIPTION
跟随 https://github.com/oomol/oocana-rust/pull/158 改动：

- 取消 client id 的启动参数要求
- 取消 client id 在消息传递中的配置要求
- 取消 address 启动参数要求，配置默认地址，与 python 保持一致
- 移除所有 Ask Reply 逻辑