### PR TITLE
fix(python_executor): 3.10 f-string SyntaxError

### DIFF
--- a/executor/python_executor/matplotlib_oomol/oomol.py
+++ b/executor/python_executor/matplotlib_oomol/oomol.py
@@ -19,7 +19,8 @@ def show(*args, **kwargs):
                 buffer.seek(0)
                 png = buffer.getvalue()
                 buffer.close()
-                url = f'data:image/png;base64,{b64encode(png).decode('utf-8')}'
+                base64Data = b64encode(png).decode('utf-8')
+                url = f'data:image/png;base64,{base64Data}'
                 images.append(url)
         if images:
             payload = { "type": "image", "data": images }


### PR DESCRIPTION
为了兼容 base 镜像的 python 版本安装了 3.10，之前的写法在 3.10 上有问题