### PR TITLE
refactor: add dataFrame protocol to better type hints

### DIFF
--- a/oocana/oocana/preview.py
+++ b/oocana/oocana/preview.py
@@ -1,5 +1,36 @@
 
-from typing import Any, TypedDict, List, Literal, TypeAlias, Union
+from typing import Any, TypedDict, List, Literal, TypeAlias, Union, Protocol, runtime_checkable
+
+# this class is for pandas.DataFrame
+@runtime_checkable
+class DataFrame(Protocol):
+
+    def __dataframe__(self, *args: Any, **kwargs: Any) -> Any:
+        ...
+
+    def to_dict(self, *args: Any, **kwargs: Any) -> Any:
+        ...
+
+@runtime_checkable
+class JsonAble(Protocol):
+
+    def to_json(self, *args: Any, **kwargs: Any) -> Any:
+        ...
+
+@runtime_checkable
+class ShapeDataFrame(DataFrame, Protocol):
+
+    @property
+    def shape(self) -> tuple[int, int]:
+        ...
+
+@runtime_checkable
+class PartialDataFrame(Protocol):
+    def head(self, *args: Any, **kwargs: Any) -> JsonAble:
+        ...
+    
+    def tail(self, *args: Any, **kwargs: Any) -> JsonAble:
+        ...
 
 class TablePreviewData(TypedDict):
     columns: List[str | int | float]
@@ -26,6 +57,10 @@ class MediaPreviewPayload(TypedDict):
     type: Literal["image", 'video', 'audio', 'markdown', "iframe", "html"]
     data: str
 
+class PandasPreviewPayload(TypedDict):
+    type: Literal['table']
+    data: DataFrame
+
 class DefaultPreviewPayload:
     type: str
     data: Any
@@ -36,5 +71,7 @@ PreviewPayload: TypeAlias = Union[
     JSONPreviewPayload,
     ImagePreviewPayload,
     MediaPreviewPayload,
+    DataFrame,
+    PandasPreviewPayload,
     DefaultPreviewPayload
 ]


### PR DESCRIPTION
1. 根据 `context.__dataframe` API 配置 Protocol，将调用的 API 转换为类型检查。
2. 移除 Any，健壮类型检查稳定性。