### PR TITLE
feat(ctx): add host info to ctx

### DIFF
--- a/oocana/oocana/context.py
+++ b/oocana/oocana/context.py
@@ -22,6 +22,12 @@ class OOMOL_LLM_ENV(TypedDict):
     api_key: str
     models: list[str]
 
+class HostInfo(TypedDict):
+    gpu_vendor: str
+    gpu_renderer: str
+    platform: str
+    arch: str
+
 class Context:
     __inputs: Dict[str, Any]
 
@@ -91,6 +97,17 @@ class Context:
             "base_url": os.getenv("OOMOL_LLM_BASE_URL", ""),
             "api_key": os.getenv("OOMOL_LLM_API_KEY", ""),
             "models": os.getenv("OOMOL_LLM_MODELS", "").split(","),
+        }
+    
+    @property
+    def host_info(self) -> HostInfo:
+        """this is a dict contains the host information
+        """
+        return {
+            "gpu_vendor": os.getenv("OOMOL_HOST_GPU_VENDOR", "unknown"),
+            "gpu_renderer": os.getenv("OOMOL_HOST_GPU_RENDERER", "unknown"),
+            "platform": os.getenv("OOMOL_HOST_PLATFORM", "unknown"),
+            "arch": os.getenv("OOMOL_HOST_ARCH", "unknown"),
         }
 
     def __store_ref(self, handle: str):


### PR DESCRIPTION
为了避免 ctx key 越来越多，这里使用了 `host_info` 作为 keys 的集合。

上游实现 PR: https://github.com/oomol/oomol-studio-core/pull/1662