### PR TITLE
feat: query block response add type field

### DIFF
--- a/flow-examples/flows/query-block/a/main.py
+++ b/flow-examples/flows/query-block/a/main.py
@@ -6,6 +6,8 @@ async def main(inputs, context: Context):
     assert run_res is not None
 
     assert isinstance(run_res, dict), "Expected run result to be a dictionary"
+    assert "type" in run_res, "Expected 'type' key to be present in the run result"
+    assert run_res["type"] == "task", "Expected type to be 'task'"
     assert "inputs_def" in run_res, "Expected 'inputs_def' key to be present in the run result"
     assert "outputs_def" in run_res, "Expected 'outputs_def' key to be present in the run result"
     assert "additional_outputs" in run_res, "Expected 'additional_outputs' key to be present in the run result"

--- a/oocana/oocana/context.py
+++ b/oocana/oocana/context.py
@@ -3,7 +3,7 @@ from dataclasses import asdict
 from .data import BlockInfo, StoreKey, JobDict, BlockDict, BinValueDict, VarValueDict
 from .mainframe import Mainframe
 from .handle import HandleDef, OutputHandleDef
-from typing import Dict, Any, TypedDict, Optional, Callable, Mapping
+from typing import Dict, Any, TypedDict, Optional, Callable, Mapping, Literal
 from types import MappingProxyType
 from base64 import b64encode
 from io import BytesIO
@@ -101,6 +101,10 @@ class HandleDefDict(TypedDict):
     """
 
 class QueryBlockResponse(TypedDict):
+
+    type: Literal["task", "subflow"]
+    """the type of the block, can be "task" or "subflow"."""
+
     description: str | None
     """the description of the block, if the block has no description, this field should be
     None.


### PR DESCRIPTION
add type field: `task` or `subflow`