### PR TITLE
fix: replace bare except with specific exception types

### DIFF
--- a/executor/python_executor/context.py
+++ b/executor/python_executor/context.py
@@ -36,7 +36,7 @@ def createContext(
                 wrap_var: VarValueDict = v
                 try:
                     ref = StoreKey(**wrap_var["value"])
-                except:  # noqa: E722
+                except (KeyError, TypeError, ValueError):
                     logger.warning(f"not valid object ref: {wrap_var}")
                     continue
                 if ref in store:


### PR DESCRIPTION
## Summary
- Replaces bare `except:` with `except (KeyError, TypeError, ValueError):`
- Bare except catches `KeyboardInterrupt` and `SystemExit`, preventing normal program termination
- Now only catches exceptions that `StoreKey.__init__` may actually raise

## Test plan
- [x] pyright type check passes
- [x] Python syntax validation passes
- [ ] Verify `KeyboardInterrupt` (Ctrl+C) properly terminates the executor