### PR TITLE
fix(oocana): prevent oomol_llm_env property side effect on repeated access

### DIFF
--- a/oocana/oocana/context.py
+++ b/oocana/oocana/context.py
@@ -185,6 +185,7 @@ class Context:
     __package_name: str | None = None
     _logger: Optional[logging.Logger] = None
     __pkg_data_dir: str
+    __oomol_llm_env_warned: bool = False
 
     # TODO: remove the pkg_dir parameter, use pkg_data_dir instead.
     def __init__(
@@ -310,11 +311,14 @@ class Context:
             "models": os.getenv("OOMOL_LLM_MODELS", "").split(","),
         }
 
-        for key, value in oomol_llm_env.items():
-            if value == "" or value == []:
-                self.send_warning(
-                    f"OOMOL_LLM_ENV variable {key} is ({value}), this may cause some features not working properly."
-                )
+        # Only warn once on first access to avoid repeated side effects
+        if not self.__oomol_llm_env_warned:
+            self.__oomol_llm_env_warned = True
+            for key, value in oomol_llm_env.items():
+                if value == "" or value == []:
+                    self.send_warning(
+                        f"OOMOL_LLM_ENV variable {key} is ({value}), this may cause some features not working properly."
+                    )
 
         return oomol_llm_env
 


### PR DESCRIPTION
## Summary

- Add `__oomol_llm_env_warned` flag to track if warning has been sent
- Only send warnings on first access to the property

## Problem

The `oomol_llm_env` property called `send_warning()` on every access:
```python
@property
def oomol_llm_env(self):
    # ...
    for key, value in oomol_llm_env.items():
        if value == "" or value == []:
            self.send_warning(...)  # Called every time!
    return oomol_llm_env
```

This violates property semantics - properties should not have side effects.

## Solution

Use a flag to warn only once:
```python
if not self.__oomol_llm_env_warned:
    self.__oomol_llm_env_warned = True
    for key, value in oomol_llm_env.items():
        if value == "" or value == []:
            self.send_warning(...)
```

## Test Plan

- [x] All existing tests pass
- [x] Warning is only sent once on first access