### PR TITLE
fix(oocana): convert CredentialInput to dataclass

### DIFF
--- a/oocana/oocana/credential.py
+++ b/oocana/oocana/credential.py
@@ -1,4 +1,16 @@
+from dataclasses import dataclass
+
+__all__ = ["CredentialInput"]
+
+
+@dataclass(frozen=True)
 class CredentialInput:
-    def __init__(self, type: str, id: str):
-        self.type = type
-        self.id = id
+    """
+    Represents a credential input for authentication queries.
+
+    Attributes:
+        type: The type of credential (e.g., 'oauth', 'api_key')
+        id: The unique identifier for the credential
+    """
+    type: str
+    id: str


### PR DESCRIPTION
## Summary

- Convert `CredentialInput` class to a frozen dataclass
- Add to `__all__` exports
- Add docstring

## Problem

`CredentialInput` was a plain class without standard data structure features:
- No automatic `__eq__`, `__hash__`, `__repr__`
- Not exported in `__all__`
- Inconsistent with other data classes in the codebase

## Solution

```python
from dataclasses import dataclass

__all__ = ["CredentialInput"]

@dataclass(frozen=True)
class CredentialInput:
    """Credential input configuration for authentication."""
    type: str
    id: str
```

## Test Plan

- [x] All existing tests pass
- [x] CredentialInput now supports equality comparison and hashing